### PR TITLE
Ajout d'un administrateur a une organisation

### DIFF
--- a/application/api/blog/app/Http/Controllers/OrganisationApi.php
+++ b/application/api/blog/app/Http/Controllers/OrganisationApi.php
@@ -65,7 +65,7 @@ class OrganisationApi extends Api
                 }
                 break;
             case self::IS_ORG_ADMIN:
-                if ($this->orgService->userIsOrgAdmin($this->me, $orgId)) {
+                if (!$this->orgService->userIsOrgAdmin($this->me, $orgId)) {
                     throw new Exception("error-permission-error");
                 }
                 break;
@@ -114,6 +114,22 @@ class OrganisationApi extends Api
 
         $users = $this->orgService->getAdminsFromOrganisation($this->org);
         return $this->returnOutput($users);
+    }
+
+    
+    /**
+     * @route post(api/organisation/{orgId}/admin/{userId]})
+     * 
+     * @param int $orgId l'id de l'organisation que l'on recherche
+     * 
+     * @return  mixed les informations de l'organisation au format JSON
+     */
+    public function addOrgAdmin(int $orgId, int $userId) {
+        $this->initialize([], self::IS_ORG_ADMIN, true, $orgId);
+
+        $userToAdd = $this->userService->getUserById($userId);
+        $this->orgService->addAdminToOrganisation($this->org, $userToAdd);
+        return $this->returnOutput($this->ack());
     }
 
     /**

--- a/application/api/blog/app/Http/Controllers/OrganisationApi.php
+++ b/application/api/blog/app/Http/Controllers/OrganisationApi.php
@@ -12,6 +12,7 @@ class OrganisationApi extends Api
     private const NO_RIGHT = 1;
     private const IS_ORG_MEMBER = 2;
     private const IS_NOT_ORG_MEMBER = 3;
+    private const IS_ORG_ADMIN = 4;
 
     private Organisation $org;
 
@@ -63,6 +64,11 @@ class OrganisationApi extends Api
                     throw new Exception("error-permission-error");
                 }
                 break;
+            case self::IS_ORG_ADMIN:
+                if ($this->orgService->userIsOrgAdmin($this->me, $orgId)) {
+                    throw new Exception("error-permission-error");
+                }
+                break;
             case self::NO_RIGHT:
             default:
                 return;
@@ -110,7 +116,7 @@ class OrganisationApi extends Api
         $this->orgService->addUserFromOrganisation($this->org, $this->me);
         return $this->returnOutput($this->ack());
     }
-    
+
     /**
      * @route post(api/organisation/)
      * 

--- a/application/api/blog/app/Http/Controllers/OrganisationApi.php
+++ b/application/api/blog/app/Http/Controllers/OrganisationApi.php
@@ -118,16 +118,23 @@ class OrganisationApi extends Api
 
     
     /**
-     * @route post(api/organisation/{orgId}/admin/{userId]})
+     * @route post(api/organisation/{orgId}/admins)
      * 
      * @param int $orgId l'id de l'organisation que l'on recherche
      * 
      * @return  mixed les informations de l'organisation au format JSON
      */
-    public function addOrgAdmin(int $orgId, int $userId) {
-        $this->initialize([], self::IS_ORG_ADMIN, true, $orgId);
+    public function addOrgAdmin(Request $request, int $orgId) {
+        $params = $this->initialize(
+            [                
+                ["mail", REQUIRED, TYPE_MAIL, $request->input('mail')],
+            ], 
+            self::IS_ORG_ADMIN, 
+            true, 
+            $orgId
+        );
 
-        $userToAdd = $this->userService->getUserById($userId);
+        $userToAdd = $this->userService->getUserByMail($params["mail"]);
         $this->orgService->addAdminToOrganisation($this->org, $userToAdd);
         return $this->returnOutput($this->ack());
     }

--- a/application/api/blog/app/manager/OrganisationManager.php
+++ b/application/api/blog/app/manager/OrganisationManager.php
@@ -175,7 +175,7 @@ class OrganisationManager extends Manager {
         return $result;
     }
 
-        /**
+    /**
      * Permet de récupéré les organisations d'un utilisateur
      * 
      * @param int $orgId l'id de l'organisation dont on veux récupéré les membres admins
@@ -189,5 +189,20 @@ class OrganisationManager extends Manager {
         $result = $this->querySelect();
         
         return $result;
+    }
+
+    /**
+     * Cette fonction permet d'ajouter un admin dans une Organisation
+     * 
+     * @return array Cette fonction retourne ou un message d'erreur ou un message disant que tout c'est bien passer
+     * 
+     */
+    public function addAdminToOrganisation(string $organisationId , string $userId): array {
+        /** @var string $request2 */    
+        $request2 = "INSERT INTO `estAdmin` (`id_Organisation`, `id_Utilisateur`) VALUES ($organisationId, $userId)";
+        $this->setQuery($request2);
+        $this->querySet();
+
+        return $this->ack("L'user a bien été ajouté a l'organisation");
     }
 }

--- a/application/api/blog/app/service/OrganisationService.php
+++ b/application/api/blog/app/service/OrganisationService.php
@@ -147,7 +147,7 @@ class  OrganisationService {
 
         // si l'utilisateur n'est pas dans l'organisation on le rajoute
         if (!$this->userIsInOrganisation($user, $org->getId())) {
-            $this->addUserFromOrganisation($org, $user);
+            throw new Exception("user-is-not-org-member");
         }
 
         $this->organisationManager->addAdminToOrganisation($org->getId(), $user->getId());

--- a/application/api/blog/app/service/OrganisationService.php
+++ b/application/api/blog/app/service/OrganisationService.php
@@ -135,4 +135,19 @@ class  OrganisationService {
 
         return $this->organisationManager->getAdminsFromOrganisation($org->getId());
     }
+
+    public function addAdminToOrganisation(Organisation $org, User $user){
+
+    }
+
+    public function userIsOrgAdmin(User $user, int $orgId): bool {
+        $admins = $this->organisationManager->getAdminsFromOrganisation($orgId);
+
+        foreach ($admins as $admin) {
+            if($admin["id_Utilisateur"] == $user->getId()){
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/application/api/blog/app/service/OrganisationService.php
+++ b/application/api/blog/app/service/OrganisationService.php
@@ -145,7 +145,6 @@ class  OrganisationService {
             throw new Exception("user-is-already-admin");
         }
 
-        // si l'utilisateur n'est pas dans l'organisation on le rajoute
         if (!$this->userIsInOrganisation($user, $org->getId())) {
             throw new Exception("user-is-not-org-member");
         }

--- a/application/api/blog/app/service/OrganisationService.php
+++ b/application/api/blog/app/service/OrganisationService.php
@@ -141,7 +141,16 @@ class  OrganisationService {
     }
 
     public function addAdminToOrganisation(Organisation $org, User $user){
+        if ($this->userIsOrgAdmin($user, $org->getId())) {
+            throw new Exception("user-is-already-admin");
+        }
 
+        // si l'utilisateur n'est pas dans l'organisation on le rajoute
+        if (!$this->userIsInOrganisation($user, $org->getId())) {
+            $this->addUserFromOrganisation($org, $user);
+        }
+
+        $this->organisationManager->addAdminToOrganisation($org->getId(), $user->getId());
     }
 
     public function userIsOrgAdmin(User $user, int $orgId): bool {

--- a/application/api/blog/routes/web.php
+++ b/application/api/blog/routes/web.php
@@ -30,4 +30,5 @@ $router->post('api/disconnect/', 'UserApi@disconnect');
 $router->get('api/organisation/{id}','OrganisationApi@getOrg');
 $router->get('api/organisation/{orgId}/members','OrganisationApi@getOrgMembers');
 $router->post('api/organisation/{orgId}/members','OrganisationApi@addOrgMembers');
+$router->post('api/organisation/{orgId}/admins/{userId}','OrganisationApi@addOrgAdmin');
 $router->post('api/organisation', 'OrganisationApi@createOrg');

--- a/application/api/blog/routes/web.php
+++ b/application/api/blog/routes/web.php
@@ -31,5 +31,5 @@ $router->get('api/organisation/{orgId}','OrganisationApi@getOrg');
 $router->get('api/organisation/{orgId}/members','OrganisationApi@getOrgMembers');
 $router->get('api/organisation/{orgId}/admins','OrganisationApi@getOrgAdmins');
 $router->post('api/organisation/{orgId}/members','OrganisationApi@addOrgMembers');
-$router->post('api/organisation/{orgId}/admins/{userId}','OrganisationApi@addOrgAdmin');
+$router->post('api/organisation/{orgId}/admins/','OrganisationApi@addOrgAdmin');
 $router->post('api/organisation', 'OrganisationApi@createOrg');


### PR DESCRIPTION
Seul un administrateur d'organisation a le droit d'en ajouter un autre.

N'importe qui peut être promu administrateur d'organisation même si il n'en fait pas partit.

Si un utilisateur ne fait pas partit d'une organisation, il y est ajouter.

Exemple d'utilisation :

POST : http://localhost:8000/api/organisation/107/admins?mail=utilisateur@a.ajouter